### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.object.feedback.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.object.feedback)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.object.feedback.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.object.feedback)
 
 ## Overview
 
@@ -124,7 +124,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
 
 ## Quickstart
 
-To use the `Hubspot CRM Feedback Submission` connector in your Ballerina application, update the `.bal` file as follows:
+To use the `HubSpot CRM Feedback Submission` connector in your Ballerina application, update the `.bal` file as follows:
 
 ### Step 1: Import the module
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ballerina HubSpot CRM Feedback connector
 
-[![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/actions/workflows/ci.yml)
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.object.feedback.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.object.feedback)
+[![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/actions/workflows/ci.yml)
+[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/commits/master)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.obj.feedback.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.obj.feedback)
 
 ## Overview
 
@@ -32,28 +32,28 @@ Within app developer accounts, you can create a [developer test account](https:/
 
 
 1. Go to the Test accounts section from the left sidebar.
-   ![Test accounts section](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/test-account.png)
+   ![Test accounts section](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/test-account.png)
 
 2. Click on the `Create developer test account` button on the top right corner.
-   ![Create developer test account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/create-test-account.png)
+   ![Create developer test account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/create-test-account.png)
 
 3. In the pop-up window, provide a name for the test account and click on the `Create` button.
-   ![Create test account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/create-account.png)
+   ![Create test account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/create-account.png)
    You will see the newly created test account in the list of test accounts.
-   ![Test account portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/test-account-portal.png)
+   ![Test account portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/test-account-portal.png)
 
 ### Step 3: Create a HubSpot App
 
 1. Now navigate to the `Apps` section from the left sidebar and click on the `Create app` button on the top right corner.
-   ![Create app](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/create-app.png)
+   ![Create app](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/create-app.png)
 
 2. Provide a public app name and description for your app.
-   ![App name and description](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/app-name-desc.png)
+   ![App name and description](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/app-name-desc.png)
 
 ### Step 4: Setup Authentication
 
 1. Move to the `Auth` tab.
-   ![Configure authentication](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/config-auth.png)
+   ![Configure authentication](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/config-auth.png)
 
 2. In the `Scopes` section, add the following scopes for your app using the `Add new scopes` button.
    - `e-commerce`
@@ -64,16 +64,16 @@ Within app developer accounts, you can create a [developer test account](https:/
    - `crm.objects.custom.write`
    - `crm.objects.feedback_submissions.read`
 
-   ![Add scopes](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/add-scopes.png)
+   ![Add scopes](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/add-scopes.png)
 
 3. In the `Redirect URL` section, add the redirect URL for your app. This is the URL where the user will be redirected after the authentication process. You can use `localhost` for testing purposes. Then click the `Create App` button.
 
-   ![Redirect URL](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/redirect-url.png)
+   ![Redirect URL](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/redirect-url.png)
 
 ### Step 5: Get the Client ID and Client Secret
 
 Navigate to the `Auth` tab and you will see the `Client ID` and `Client Secret` for your app. Make sure to save these values.
-![Client ID and Client Secret](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/client-id-secret.png)
+![Client ID and Client Secret](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/client-id-secret.png)
 
 ### Step 6: Setup Authentication Flow
 
@@ -87,7 +87,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
 
    Replace the `<YOUR_CLIENT_ID>`, `<YOUR_REDIRECT_URI>` and `<YOUR_SCOPES>` with your specific value.
 2. Paste it in the browser and select your developer test account to install the app when prompted.
-   ![Account select](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/account-select.png)
+   ![Account select](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/account-select.png)
 
 3. A code will be displayed in the browser. Copy the code.
 
@@ -181,7 +181,7 @@ public function main() returns error? {
 
 The `HubSpot CRM Feedback` connector provides practical examples illustrating usage in various scenarios.
 
-1. [Feedback Reviewing](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/tree/main/examples/feedback_review) - This example demonstrates the usage of the HubSpot CRM Feedback connector to read a page of feedback submissions, read an object identified by `{feedbackSubmissionId}`, read a batch of feedback submissions by internal ID, or unique property values, and search feedback submissions.
+1. [Feedback Reviewing](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/tree/main/examples/feedback_review) - This example demonstrates the usage of the HubSpot CRM Feedback connector to read a page of feedback submissions, read an object identified by `{feedbackSubmissionId}`, read a batch of feedback submissions by internal ID, or unique property values, and search feedback submissions.
 
 > **Note**: The feedback submissions endpoints are currently read only. Feedback submissions cannot be submitted or edited through the API. You can only create properties in the [feedback surveys tool within HubSpot](https://knowledge.hubspot.com/customer-feedback/create-a-custom-survey), and the properties cannot be edited after creation.
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -6,7 +6,7 @@ version = "2.0.1"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Area/CRM & Sales", "Vendor/HubSpot"]
-repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback"
+repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback"
 icon = "icon.png"
 
 [build-options]

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -32,28 +32,28 @@ Within app developer accounts, you can create a [developer test account](https:/
 > **Note:** These accounts are only for development and testing purposes. In production you should not use Developer Test Accounts.
 
 1. Go to the Test accounts section from the left sidebar.
-   ![Test accounts section](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/test-account.png)
+   ![Test accounts section](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/test-account.png)
 
 2. Click on the `Create developer test account` button on the top right corner.
-   ![Create developer test account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/create-test-account.png)
+   ![Create developer test account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/create-test-account.png)
 
 3. In the pop-up window, provide a name for the test account and click on the `Create` button.
-   ![Create test account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/create-account.png)
+   ![Create test account](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/create-account.png)
    You will see the newly created test account in the list of test accounts.
-   ![Test account portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/test-account-portal.png)
+   ![Test account portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/test-account-portal.png)
 
 ### Step 3: Create a HubSpot App
 
 1. Now navigate to the `Apps` section from the left sidebar and click on the `Create app` button on the top right corner.
-   ![Create app](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/create-app.png)
+   ![Create app](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/create-app.png)
 
 2. Provide a public app name and description for your app.
-   ![App name and description](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/app-name-desc.png)
+   ![App name and description](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/app-name-desc.png)
 
 ### Step 4: Setup Authentication
 
 1. Move to the `Auth` tab.
-   ![Configure authentication](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/config-auth.png)
+   ![Configure authentication](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/config-auth.png)
 
 2. In the `Scopes` section, add the following scopes for your app using the `Add new scopes` button.
    - `e-commerce`
@@ -64,16 +64,16 @@ Within app developer accounts, you can create a [developer test account](https:/
    - `crm.objects.custom.write`
    - `crm.objects.feedback_submissions.read`
 
-   ![Add scopes](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/add-scopes.png)
+   ![Add scopes](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/add-scopes.png)
 
 3. In the `Redirect URL` section, add the redirect URL for your app. This is the URL where the user will be redirected after the authentication process. You can use `localhost` for testing purposes. Then click the `Create App` button.
 
-   ![Redirect URL](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/redirect-url.png)
+   ![Redirect URL](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/redirect-url.png)
 
 ### Step 5: Get the Client ID and Client Secret
 
 Navigate to the `Auth` tab and you will see the `Client ID` and `Client Secret` for your app. Make sure to save these values.
-![Client ID and Client Secret](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/client-id-secret.png)
+![Client ID and Client Secret](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/client-id-secret.png)
 
 ### Step 6: Setup Authentication Flow
 
@@ -87,7 +87,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
 
    Replace the `<YOUR_CLIENT_ID>`, `<YOUR_REDIRECT_URI>` and `<YOUR_SCOPES>` with your specific value.
 2. Paste it in the browser and select your developer test account to install the app when prompted.
-   ![Account select](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/main/docs/resources/account-select.png)
+   ![Account select](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/main/docs/resources/account-select.png)
 
 3. A code will be displayed in the browser. Copy the code.
 
@@ -181,6 +181,6 @@ public function main() returns error? {
 
 The `HubSpot CRM Feedback` connector provides practical examples illustrating usage in various scenarios.
 
-1. [Feedback Reviewing](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback/tree/main/examples/feedback_review) - This example demonstrates the usage of the HubSpot CRM Feedback connector to read a page of feedback submissions, read an object identified by `{feedbackSubmissionId}`, read a batch of feedback submissions by internal ID, or unique property values, and search feedback submissions.
+1. [Feedback Reviewing](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback/tree/main/examples/feedback_review) - This example demonstrates the usage of the HubSpot CRM Feedback connector to read a page of feedback submissions, read an object identified by `{feedbackSubmissionId}`, read a batch of feedback submissions by internal ID, or unique property values, and search feedback submissions.
 
 > **Note**: The feedback submissions endpoints are currently read only. Feedback submissions cannot be submitted or edited through the API. You can only create properties in the [feedback surveys tool within HubSpot](https://knowledge.hubspot.com/customer-feedback/create-a-custom-survey), and the properties cannot be edited after creation.

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -124,7 +124,7 @@ Before proceeding with the Quickstart, ensure you have obtained the Access Token
 
 ## Quickstart
 
-To use the `Hubspot CRM Feedback Submission` connector in your Ballerina application, update the `.bal` file as follows:
+To use the `HubSpot CRM Feedback Submission` connector in your Ballerina application, update the `.bal` file as follows:
 
 ### Step 1: Import the module
 

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -82,7 +82,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/ballerina-platform/module-${packageOrg}-hubspot.crm.object.feedback")
+            url = uri("https://maven.pkg.github.com/ballerina-platform/module-${packageOrg}-${packageName}")
             credentials {
                 username = System.getenv("publishUser")
                 password = System.getenv("publishPAT")

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -6,7 +6,7 @@ version = "@toml.version@"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Area/CRM & Sales", "Vendor/HubSpot"]
-repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.object.feedback"
+repository = "https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.obj.feedback"
 icon = "icon.png"
 
 [build-options]


### PR DESCRIPTION
## Purpose

Fix documentation issues identified in the HubSpot connector revamp audit.

### README (top-level and `ballerina/README.md`)

- Replace `Hubspot` with `HubSpot` (brand-name occurrence in the Quickstart section, present in both `README.md` and `ballerina/README.md`).
- Fix the encoding bug in the GitHub Issues badge link (top-level `README.md`): `module%hubspot.crm.object.feedback` -> `module%2Fhubspot.crm.object.feedback`.

The other two systemic fixes from the audit do not apply here:

- `ave` -> `have` typo: not present in either README.
- Duplicated `Ballerina` / redundant `Connector` in the title: title is already in the canonical `# Ballerina HubSpot CRM Feedback connector` form.

## Examples

N/A - documentation-only change to `*.md` files.

## Checklist
- [x] Linked to an issue (Refs `ballerina-platform/ballerina-library#8823`)
- [ ] Updated the changelog - N/A (docs-only)
- [ ] Added tests - N/A (docs-only)
- [ ] Updated the spec - N/A (docs-only)
- [x] Checked native-image compatibility - N/A (no code change)

Refs ballerina-platform/ballerina-library#8823