### PR TITLE
fix: update release workflow to use @main template and fix package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
   call_workflow:
     name: Run Release Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-connector-template.yml@2201.10.x
+    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-connector-template.yml@main
     secrets: inherit
     with:
-      package-name: hubspot.crm.object.feedback
+      package-name: hubspot.crm.obj.feedback
       package-org: ballerinax


### PR DESCRIPTION
## Summary

- Updated the reusable workflow reference from `@2201.10.x` to `@main` to use Java 21 compatible template
- Fixed package name from `hubspot.crm.object.feedback` to `hubspot.crm.obj.feedback` to match the actual Ballerina Central package identifier

## Root Cause

The `@2201.10.x` template pins JDK 17, which is incompatible with `distribution = "2201.12.0"` in `Ballerina.toml` that requires Java 21. The package name mismatch would cause publish failures to Ballerina Central.